### PR TITLE
Role can be empty

### DIFF
--- a/src/Data/Geo/OSM/Member.hs
+++ b/src/Data/Geo/OSM/Member.hs
@@ -21,7 +21,7 @@ data Member =
 instance XmlPickler Member where
   xpickle =
     xpElem "member" (xpWrap (\(mtype', mref', mrole') -> member mtype' mref' mrole', \(Member mtype' mref' mrole') -> (mtype', mref', mrole'))
-                    (xpTriple xpickle (xpAttr "ref" xpText) (xpAttr "role" xpText)))
+                    (xpTriple xpickle (xpAttr "ref" xpText) (xpAttr "role" xpText0)))
 
 instance Show Member where
   show =


### PR DESCRIPTION
The role attribute of a member in a relation can be empty.  I changed the `xpText` to an `xpText0` to handle this.  See http://wiki.openstreetmap.org/wiki/Relations.
