### PR TITLE
Depend on comonad instead of the deprecated comonad-transformers

### DIFF
--- a/OSM.cabal
+++ b/OSM.cabal
@@ -24,7 +24,7 @@ Library
                       , hxt >= 9
                       , containers
                       , data-lens
-                      , comonad-transformers
+                      , comonad >= 4
                       , newtype
 
   GHC-Options:        -Wall


### PR DESCRIPTION
[comonad-transformers](http://hackage.haskell.org/package/comonad-transformers) has been deprecated in favor of comonad. This should also close #3.

Cheers!
