### PR TITLE
refactored from data-lens to lens

### DIFF
--- a/OSM.cabal
+++ b/OSM.cabal
@@ -23,7 +23,7 @@ Library
   Build-Depends:      base < 5 && >= 3
                       , hxt >= 9
                       , containers
-                      , data-lens
+                      , lens
                       , comonad >= 4
                       , newtype
 
@@ -97,4 +97,3 @@ Library
                       Data.Geo.OSM.Lens.VL
                       Data.Geo.OSM.Lens.WaynodesL
                       Data.Geo.OSM.Lens.ZoomL
-

--- a/OSM.cabal
+++ b/OSM.cabal
@@ -7,7 +7,7 @@ Description:          Parse OpenStreetMap http:\/\/osm.org/ files using HXT into
                       The Data.Geo.OSM module is the core module that exports all others.
 Homepage:             https://github.com/tonymorris/geo-osm
 Category:             Utils
-Author:               Tony Morris <ʇǝu˙sıɹɹoɯʇ@ןןǝʞsɐɥ>, Thomas DuBuisson
+Author:               Tony Morris <ʇǝu˙sıɹɹoɯʇ@ןןǝʞsɐɥ>, Thomas DuBuisson, Markus Barenhoff
 Maintainer:           Tony Morris, Thomas DuBuisson
 Copyright:            2009 -- 2012 Tony Morris, Thomas DuBuisson
 Build-Type:           Simple
@@ -24,7 +24,6 @@ Library
                       , hxt >= 9
                       , containers
                       , lens
-                      , comonad >= 4
                       , newtype
 
   GHC-Options:        -Wall

--- a/src/Data/Geo/OSM/Api.hs
+++ b/src/Data/Geo/OSM/Api.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE MultiParamTypeClasses, TypeSynonymInstances, FlexibleInstances #-}
 
 -- | The @api@ element of a OSM file.
@@ -12,17 +13,22 @@ import Data.Geo.OSM.Version
 import Data.Geo.OSM.Area
 import Data.Geo.OSM.Tracepoints
 import Data.Geo.OSM.Waynodes
-import Control.Lens.Lens
-import Control.Comonad.Trans.Store
+import Control.Lens.TH
+
 import Data.Geo.OSM.Lens.VersionL
 import Data.Geo.OSM.Lens.AreaL
 import Data.Geo.OSM.Lens.TracepointsL
 import Data.Geo.OSM.Lens.WaynodesL
 
 -- | The @api@ element of a OSM file.
-data Api =
-  Api Version Area Tracepoints Waynodes
-  deriving Eq
+data Api = Api {
+  _apiVersion :: Version,
+  _apiArea :: Area,
+  _apiTracepoints :: Tracepoints,
+  _apiWaynodes :: Waynodes
+  } deriving Eq
+
+makeLenses ''Api
 
 -- | Constructs a @api@ with version, area, tracepoints and waynodes.
 api ::
@@ -43,18 +49,13 @@ instance Show Api where
     showPickled []
 
 instance VersionL Api Version where
-  versionL =
-    Lens $ \(Api version area tracepoints waynodes) -> store (\version -> Api version area tracepoints waynodes) version
+  versionL = apiVersion
 
 instance AreaL Api where
-  areaL =
-    Lens $ \(Api version area tracepoints waynodes) -> store (\area -> Api version area tracepoints waynodes) area
+  areaL = apiArea
 
 instance TracepointsL Api where
-  tracepointsL =
-    Lens $ \(Api version area tracepoints waynodes) -> store (\tracepoints -> Api version area tracepoints waynodes) tracepoints
+  tracepointsL = apiTracepoints
 
 instance WaynodesL Api where
-  waynodesL =
-    Lens $ \(Api version area tracepoints waynodes) -> store (\waynodes -> Api version area tracepoints waynodes) waynodes
-
+  waynodesL = apiWaynodes

--- a/src/Data/Geo/OSM/Api.hs
+++ b/src/Data/Geo/OSM/Api.hs
@@ -12,7 +12,7 @@ import Data.Geo.OSM.Version
 import Data.Geo.OSM.Area
 import Data.Geo.OSM.Tracepoints
 import Data.Geo.OSM.Waynodes
-import Data.Lens.Common
+import Control.Lens.Lens
 import Control.Comonad.Trans.Store
 import Data.Geo.OSM.Lens.VersionL
 import Data.Geo.OSM.Lens.AreaL

--- a/src/Data/Geo/OSM/Area.hs
+++ b/src/Data/Geo/OSM/Area.hs
@@ -9,7 +9,7 @@ module Data.Geo.OSM.Area
 
 import Text.XML.HXT.Arrow.Pickle
 import Data.Geo.OSM.Lens.MaximumL
-import Data.Lens.Common
+import Control.Lens.Lens
 import Control.Comonad.Trans.Store
 import Control.Newtype
 

--- a/src/Data/Geo/OSM/Area.hs
+++ b/src/Data/Geo/OSM/Area.hs
@@ -10,7 +10,7 @@ module Data.Geo.OSM.Area
 import Text.XML.HXT.Arrow.Pickle
 import Data.Geo.OSM.Lens.MaximumL
 import Control.Lens.Lens
-import Control.Comonad.Trans.Store
+
 import Control.Newtype
 
 -- | The @area@ element of a OSM file.
@@ -35,10 +35,10 @@ instance Show Area where
 
 instance MaximumL Area where
   maximumL =
-    Lens $ \(Area maximum) -> store (\maximum -> Area maximum) maximum
+    lens unpack (const pack)
 
 instance Newtype Area String where
-  pack = 
+  pack =
     Area
   unpack (Area x) =
     x

--- a/src/Data/Geo/OSM/Bound.hs
+++ b/src/Data/Geo/OSM/Bound.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TemplateHaskell #-}
 -- | The @bound@ element of a OSM file.
 module Data.Geo.OSM.Bound
 (
@@ -8,13 +9,15 @@ module Data.Geo.OSM.Bound
 import Text.XML.HXT.Arrow.Pickle
 import Data.Geo.OSM.Lens.BoxL
 import Data.Geo.OSM.Lens.OriginL
-import Control.Lens.Lens
-import Control.Comonad.Trans.Store
+import Control.Lens.TH
 
 -- | The @bound@ element of a OSM file.
-data Bound =
-  Bound String (Maybe String)
-  deriving Eq
+data Bound = Bound {
+  _boundBox :: String,
+  _boundOrigin :: Maybe String
+  } deriving Eq
+makeLenses ''Bound
+
 
 instance XmlPickler Bound where
   xpickle =
@@ -25,12 +28,10 @@ instance Show Bound where
     showPickled []
 
 instance BoxL Bound where
-  boxL =
-    Lens $ \(Bound box origin) -> store (\box -> Bound box origin) box
+  boxL = boundBox
 
 instance OriginL Bound where
-  originL =
-    Lens $ \(Bound box origin) -> store (\origin -> Bound box origin) origin
+  originL = boundOrigin
 
 -- | Constructs a bound with a box and origin attributes.
 bound ::

--- a/src/Data/Geo/OSM/Bound.hs
+++ b/src/Data/Geo/OSM/Bound.hs
@@ -8,7 +8,7 @@ module Data.Geo.OSM.Bound
 import Text.XML.HXT.Arrow.Pickle
 import Data.Geo.OSM.Lens.BoxL
 import Data.Geo.OSM.Lens.OriginL
-import Data.Lens.Common
+import Control.Lens.Lens
 import Control.Comonad.Trans.Store
 
 -- | The @bound@ element of a OSM file.

--- a/src/Data/Geo/OSM/BoundOption.hs
+++ b/src/Data/Geo/OSM/BoundOption.hs
@@ -1,7 +1,7 @@
 -- | A bound-option is either a @Bound@, @Bounds@ or empty.
 module Data.Geo.OSM.BoundOption
 (
-  BoundOption
+  BoundOption, _BoundOptions
 , foldBoundOption
 , optionBound
 , optionBounds
@@ -10,12 +10,25 @@ module Data.Geo.OSM.BoundOption
 
 import Data.Geo.OSM.Bound
 import Data.Geo.OSM.Bounds
+import Control.Lens.Iso
+
 
 data BoundOption =
   OptionBound Bound
   | OptionBounds Bounds
   | Empty
   deriving Eq
+
+_BoundOptions :: Iso' (Maybe (Either Bound Bounds)) BoundOption
+_BoundOptions = iso toBoundOptions fromBoundOptions
+  where
+    toBoundOptions Nothing = optionEmptyBound
+    toBoundOptions (Just (Left b)) = optionBound b
+    toBoundOptions (Just (Right b)) = optionBounds b
+    fromBoundOptions Empty = Nothing
+    fromBoundOptions (OptionBound b) = Just (Left b)
+    fromBoundOptions (OptionBounds b) = Just (Right b)
+
 
 foldBoundOption ::
   (Bound -> x)

--- a/src/Data/Geo/OSM/Bounds.hs
+++ b/src/Data/Geo/OSM/Bounds.hs
@@ -11,7 +11,7 @@ import Data.Geo.OSM.Lens.MaxlatL
 import Data.Geo.OSM.Lens.MinlonL
 import Data.Geo.OSM.Lens.MaxlonL
 import Data.Geo.OSM.Lens.OriginL
-import Data.Lens.Common
+import Control.Lens.Lens
 import Control.Comonad.Trans.Store
 
 -- | The @bounds@ element of a OSM file.

--- a/src/Data/Geo/OSM/Bounds.hs
+++ b/src/Data/Geo/OSM/Bounds.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TemplateHaskell #-}
 -- | The @bounds@ element of a OSM file.
 module Data.Geo.OSM.Bounds
 (
@@ -11,13 +12,18 @@ import Data.Geo.OSM.Lens.MaxlatL
 import Data.Geo.OSM.Lens.MinlonL
 import Data.Geo.OSM.Lens.MaxlonL
 import Data.Geo.OSM.Lens.OriginL
-import Control.Lens.Lens
-import Control.Comonad.Trans.Store
+import Control.Lens.TH
 
 -- | The @bounds@ element of a OSM file.
-data Bounds =
-  Bounds String String String String (Maybe String)
-  deriving Eq
+data Bounds = Bounds {
+  _boundsMinLat :: String,
+  _boundsMinLon :: String,
+  _boundsMaxLat :: String,
+  _boundsMaxLon :: String,
+  _boundsOrigin :: Maybe String
+  } deriving Eq
+
+makeLenses ''Bounds
 
 instance XmlPickler Bounds where
   xpickle =
@@ -29,24 +35,19 @@ instance Show Bounds where
     showPickled []
 
 instance MinlatL Bounds where
-  minlatL =
-    Lens $ \(Bounds minlat minlon maxlat maxlon origin) -> store (\minlat -> Bounds minlat minlon maxlat maxlon origin) minlat
+  minlatL = boundsMinLat
 
 instance MinlonL Bounds where
-  minlonL =
-    Lens $ \(Bounds minlat minlon maxlat maxlon origin) -> store (\minlon -> Bounds minlat minlon maxlat maxlon origin) minlon
+  minlonL = boundsMinLon
 
 instance MaxlatL Bounds where
-  maxlatL =
-    Lens $ \(Bounds minlat minlon maxlat maxlon origin) -> store (\maxlat -> Bounds minlat minlon maxlat maxlon origin) maxlat
+  maxlatL = boundsMaxLat
 
 instance MaxlonL Bounds where
-  maxlonL =
-    Lens $ \(Bounds minlat minlon maxlat maxlon origin) -> store (\maxlon -> Bounds minlat minlon maxlat maxlon origin) maxlon
+  maxlonL = boundsMaxLon
 
 instance OriginL Bounds where
-  originL =
-    Lens $ \(Bounds minlat minlon maxlat maxlon origin) -> store (\origin -> Bounds minlat minlon maxlat maxlon origin) origin
+  originL = boundsOrigin
 
 -- | Constructs a bounds with a minlat, minlon, maxlat, maxlon and origin attributes.
 bounds ::

--- a/src/Data/Geo/OSM/Changeset.hs
+++ b/src/Data/Geo/OSM/Changeset.hs
@@ -11,7 +11,6 @@ import Text.XML.HXT.Arrow.Pickle
 import Data.Geo.OSM.Tag
 import Data.Geo.OSM.Lens.TagsL
 import Control.Lens.Lens
-import Control.Comonad.Trans.Store
 import Control.Newtype
 
 -- | The @changeset@ element of a OSM file.
@@ -36,11 +35,10 @@ instance Show Changeset where
 
 instance TagsL Changeset where
   tagsL =
-    Lens $ \(Changeset tags) -> store (\tags -> Changeset tags) tags
+    lens unpack (const pack)
 
 instance Newtype Changeset [Tag] where
-  pack = 
+  pack =
     Changeset
   unpack (Changeset x) =
     x
-

--- a/src/Data/Geo/OSM/Changeset.hs
+++ b/src/Data/Geo/OSM/Changeset.hs
@@ -10,7 +10,7 @@ module Data.Geo.OSM.Changeset
 import Text.XML.HXT.Arrow.Pickle
 import Data.Geo.OSM.Tag
 import Data.Geo.OSM.Lens.TagsL
-import Data.Lens.Common
+import Control.Lens.Lens
 import Control.Comonad.Trans.Store
 import Control.Newtype
 

--- a/src/Data/Geo/OSM/GpxFile.hs
+++ b/src/Data/Geo/OSM/GpxFile.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE MultiParamTypeClasses, TypeSynonymInstances, FlexibleInstances #-}
+{-# LANGUAGE TemplateHaskell, MultiParamTypeClasses, TypeSynonymInstances, FlexibleInstances #-}
 
 -- | The @gpx_file@ element of a OSM file.
 module Data.Geo.OSM.GpxFile
@@ -17,13 +17,22 @@ import Data.Geo.OSM.Lens.UserL
 import Data.Geo.OSM.Lens.PublicL
 import Data.Geo.OSM.Lens.PendingL
 import Data.Geo.OSM.Lens.TimestampL
-import Control.Lens.Lens
-import Control.Comonad.Trans.Store
+import Control.Lens.TH
+
 
 -- | The @gpx_file@ element of a OSM file.
-data GpxFile =
-  GpxFile String String String String String Bool Bool String
-  deriving Eq
+data GpxFile = GpxFile {
+  _gpxFileId :: String,
+  _gpxFileName :: String,
+  _gpxFileLat :: String,
+  _gpxFileLon :: String,
+  _gpxFileUser :: String,
+  _gpxFilePublic ::Bool,
+  _gpxFilePending :: Bool,
+  _gpxFileTimestamp :: String
+  } deriving Eq
+
+makeLenses ''GpxFile
 
 -- | Constructs a @gpx_file@ with an id, name, lat, lon, user, public, pending and timestamp.
 gpxFile ::
@@ -52,34 +61,25 @@ instance Show GpxFile where
     showPickled []
 
 instance IdL GpxFile where
-  idL =
-    Lens $ \(GpxFile id name lat lon user public pending timestamp) -> store (\id -> GpxFile id name lat lon user public pending timestamp) id
+  idL = gpxFileId
 
 instance NameL GpxFile where
-  nameL =
-    Lens $ \(GpxFile id name lat lon user public pending timestamp) -> store (\name -> GpxFile id name lat lon user public pending timestamp) name
+  nameL = gpxFileName
 
 instance LatL GpxFile where
-  latL =
-    Lens $ \(GpxFile id name lat lon user public pending timestamp) -> store (\lat -> GpxFile id name lat lon user public pending timestamp) lat
+  latL = gpxFileLat
 
 instance LonL GpxFile where
-  lonL =
-    Lens $ \(GpxFile id name lat lon user public pending timestamp) -> store (\lon -> GpxFile id name lat lon user public pending timestamp) lon
+  lonL = gpxFileLon
 
 instance UserL GpxFile String where
-  userL =
-    Lens $ \(GpxFile id name lat lon user public pending timestamp) -> store (\user -> GpxFile id name lat lon user public pending timestamp) user
+  userL = gpxFileUser
 
 instance PublicL GpxFile where
-  publicL =
-    Lens $ \(GpxFile id name lat lon user public pending timestamp) -> store (\public -> GpxFile id name lat lon user public pending timestamp) public
+  publicL = gpxFilePublic
 
 instance PendingL GpxFile where
-  pendingL =
-    Lens $ \(GpxFile id name lat lon user public pending timestamp) -> store (\pending -> GpxFile id name lat lon user public pending timestamp) pending
+  pendingL = gpxFilePending
 
 instance TimestampL GpxFile String where
-  timestampL =
-    Lens $ \(GpxFile id name lat lon user public pending timestamp) -> store (\timestamp -> GpxFile id name lat lon user public pending timestamp) timestamp
-
+  timestampL = gpxFileTimestamp

--- a/src/Data/Geo/OSM/GpxFile.hs
+++ b/src/Data/Geo/OSM/GpxFile.hs
@@ -17,7 +17,7 @@ import Data.Geo.OSM.Lens.UserL
 import Data.Geo.OSM.Lens.PublicL
 import Data.Geo.OSM.Lens.PendingL
 import Data.Geo.OSM.Lens.TimestampL
-import Data.Lens.Common
+import Control.Lens.Lens
 import Control.Comonad.Trans.Store
 
 -- | The @gpx_file@ element of a OSM file.

--- a/src/Data/Geo/OSM/Home.hs
+++ b/src/Data/Geo/OSM/Home.hs
@@ -9,7 +9,7 @@ import Text.XML.HXT.Arrow.Pickle
 import Data.Geo.OSM.Lens.LatL
 import Data.Geo.OSM.Lens.LonL
 import Data.Geo.OSM.Lens.ZoomL
-import Data.Lens.Common
+import Control.Lens.Lens
 import Control.Comonad.Trans.Store
 
 -- | The @home@ element of a OSM file.

--- a/src/Data/Geo/OSM/Home.hs
+++ b/src/Data/Geo/OSM/Home.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TemplateHaskell #-}
 -- | The @home@ element of a OSM file.
 module Data.Geo.OSM.Home
 (
@@ -9,13 +10,17 @@ import Text.XML.HXT.Arrow.Pickle
 import Data.Geo.OSM.Lens.LatL
 import Data.Geo.OSM.Lens.LonL
 import Data.Geo.OSM.Lens.ZoomL
-import Control.Lens.Lens
-import Control.Comonad.Trans.Store
+
+
+import Control.Lens.TH
 
 -- | The @home@ element of a OSM file.
-data Home =
-  Home String String String
-  deriving Eq
+data Home = Home {
+  _homeLat :: String,
+  _homeLon :: String,
+  _homeZoom :: String
+  } deriving Eq
+makeLenses ''Home
 
 -- | Constructs a @home@ with lat, lon and zoom.
 home ::
@@ -35,14 +40,10 @@ instance Show Home where
     showPickled []
 
 instance LatL Home where
-  latL =
-    Lens $ \(Home lat lon zoom) -> store (\lat -> Home lat lon zoom) lat
+  latL = homeLat
 
 instance LonL Home where
-  lonL =
-    Lens $ \(Home lat lon zoom) -> store (\lon -> Home lat lon zoom) lon
+  lonL = homeLon
 
 instance ZoomL Home where
-  zoomL =
-    Lens $ \(Home lat lon zoom) -> store (\zoom -> Home lat lon zoom) zoom
-
+  zoomL = homeZoom

--- a/src/Data/Geo/OSM/Lens/AccountCreatedL.hs
+++ b/src/Data/Geo/OSM/Lens/AccountCreatedL.hs
@@ -1,8 +1,8 @@
 -- | Values with a @account_created@ string accessor.
 module Data.Geo.OSM.Lens.AccountCreatedL where
 
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class AccountCreatedL a where
-  accountCreatedL :: 
-    Lens a String
+  accountCreatedL ::
+    Lens' a String

--- a/src/Data/Geo/OSM/Lens/AreaL.hs
+++ b/src/Data/Geo/OSM/Lens/AreaL.hs
@@ -2,8 +2,8 @@
 module Data.Geo.OSM.Lens.AreaL where
 
 import Data.Geo.OSM.Area
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class AreaL a where
   areaL ::
-    Lens a Area
+    Lens' a Area

--- a/src/Data/Geo/OSM/Lens/BoundsL.hs
+++ b/src/Data/Geo/OSM/Lens/BoundsL.hs
@@ -1,10 +1,10 @@
 -- | Values with a @bounds@ accessor which is either empty, a @Bound@ or a @Bounds@.
 module Data.Geo.OSM.Lens.BoundsL where
 
-import Data.Lens.Common
+import Control.Lens.Lens
 import Data.Geo.OSM.BoundOption
 
 class BoundsL a where
   boundsL ::
-    Lens a BoundOption
+    Lens' a BoundOption
 

--- a/src/Data/Geo/OSM/Lens/BoxL.hs
+++ b/src/Data/Geo/OSM/Lens/BoxL.hs
@@ -1,9 +1,9 @@
 -- | Values with a @box@ string accessor.
 module Data.Geo.OSM.Lens.BoxL where
 
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class BoxL a where
   boxL ::
-    Lens a String
+    Lens' a String
 

--- a/src/Data/Geo/OSM/Lens/ChangesetL.hs
+++ b/src/Data/Geo/OSM/Lens/ChangesetL.hs
@@ -1,9 +1,8 @@
 -- | Values with a @changeset@ optional string accessor.
 module Data.Geo.OSM.Lens.ChangesetL where
 
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class ChangesetL a where
   changesetL ::
-    Lens a (Maybe String)
-
+    Lens' a (Maybe String)

--- a/src/Data/Geo/OSM/Lens/ChildrenL.hs
+++ b/src/Data/Geo/OSM/Lens/ChildrenL.hs
@@ -2,9 +2,9 @@
 module Data.Geo.OSM.Lens.ChildrenL where
 
 import Data.Geo.OSM.Children
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class ChildrenL a where
   childrenL ::
-    Lens a Children
+    Lens' a Children
 

--- a/src/Data/Geo/OSM/Lens/DisplayNameL.hs
+++ b/src/Data/Geo/OSM/Lens/DisplayNameL.hs
@@ -1,9 +1,9 @@
 -- | Values with a @display_name@ string accessor.
 module Data.Geo.OSM.Lens.DisplayNameL where
 
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class DisplayNameL a where
   displayNameL ::
-    Lens a String
+    Lens' a String
 

--- a/src/Data/Geo/OSM/Lens/GeneratorL.hs
+++ b/src/Data/Geo/OSM/Lens/GeneratorL.hs
@@ -1,9 +1,9 @@
 -- | Values with a @generator@ optional string accessor.
 module Data.Geo.OSM.Lens.GeneratorL where
 
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class GeneratorL a where
   generatorL ::
-    Lens a (Maybe String)
+    Lens' a (Maybe String)
 

--- a/src/Data/Geo/OSM/Lens/HomeL.hs
+++ b/src/Data/Geo/OSM/Lens/HomeL.hs
@@ -1,10 +1,10 @@
 -- | Values with a @home@ optional string accessor.
 module Data.Geo.OSM.Lens.HomeL where
 
-import Data.Lens.Common
+import Control.Lens.Lens
 import Data.Geo.OSM.Home
 
 class HomeL a where
   homeL ::
-    Lens a (Maybe Home)
+    Lens' a (Maybe Home)
 

--- a/src/Data/Geo/OSM/Lens/IdL.hs
+++ b/src/Data/Geo/OSM/Lens/IdL.hs
@@ -1,9 +1,9 @@
 -- | Values with a @id@ string accessor.
 module Data.Geo.OSM.Lens.IdL where
 
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class IdL a where
   idL ::
-    Lens a String
+    Lens' a String
 

--- a/src/Data/Geo/OSM/Lens/KL.hs
+++ b/src/Data/Geo/OSM/Lens/KL.hs
@@ -1,9 +1,9 @@
 -- | Values with a @k@ string accessor.
 module Data.Geo.OSM.Lens.KL where
 
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class KL a where
   kL ::
-    Lens a String
+    Lens' a String
 

--- a/src/Data/Geo/OSM/Lens/LatL.hs
+++ b/src/Data/Geo/OSM/Lens/LatL.hs
@@ -1,9 +1,9 @@
 -- | Values with a @lat@ string accessor.
 module Data.Geo.OSM.Lens.LatL where
 
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class LatL a where
   latL ::
-    Lens a String
+    Lens' a String
 

--- a/src/Data/Geo/OSM/Lens/LonL.hs
+++ b/src/Data/Geo/OSM/Lens/LonL.hs
@@ -1,9 +1,9 @@
 -- | Values with a @lon@ string accessor.
 module Data.Geo.OSM.Lens.LonL where
 
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class LonL a where
   lonL ::
-    Lens a String
+    Lens' a String
 

--- a/src/Data/Geo/OSM/Lens/MaximumL.hs
+++ b/src/Data/Geo/OSM/Lens/MaximumL.hs
@@ -1,9 +1,9 @@
 -- | Values with a @maximum@ string accessor.
 module Data.Geo.OSM.Lens.MaximumL where
 
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class MaximumL a where
   maximumL :: 
-    Lens a String
+    Lens' a String
 

--- a/src/Data/Geo/OSM/Lens/MaxlatL.hs
+++ b/src/Data/Geo/OSM/Lens/MaxlatL.hs
@@ -1,9 +1,9 @@
 -- | Values with a @maxlat@ string accessor.
 module Data.Geo.OSM.Lens.MaxlatL where
 
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class MaxlatL a where
   maxlatL :: 
-    Lens a String
+    Lens' a String
 

--- a/src/Data/Geo/OSM/Lens/MaxlonL.hs
+++ b/src/Data/Geo/OSM/Lens/MaxlonL.hs
@@ -1,9 +1,9 @@
 -- -- | Values with a @maxlon@ string accessor.
 module Data.Geo.OSM.Lens.MaxlonL where
 
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class MaxlonL a where
   maxlonL ::
-    Lens a String
+    Lens' a String
 

--- a/src/Data/Geo/OSM/Lens/MemberL.hs
+++ b/src/Data/Geo/OSM/Lens/MemberL.hs
@@ -2,9 +2,9 @@
 module Data.Geo.OSM.Lens.MemberL where
 
 import Data.Geo.OSM.Member
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class MemberL a where
   memberL ::
-    Lens a [Member]
+    Lens' a [Member]
 

--- a/src/Data/Geo/OSM/Lens/MinimumL.hs
+++ b/src/Data/Geo/OSM/Lens/MinimumL.hs
@@ -1,8 +1,8 @@
 -- | Values with a @minimum@ string accessor.
 module Data.Geo.OSM.Lens.MinimumL where
 
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class MinimumL a where
   minimumL :: 
-    Lens a String
+    Lens' a String

--- a/src/Data/Geo/OSM/Lens/MinlatL.hs
+++ b/src/Data/Geo/OSM/Lens/MinlatL.hs
@@ -1,9 +1,9 @@
 -- | Values with a @minlat@ string accessor.
 module Data.Geo.OSM.Lens.MinlatL where
 
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class MinlatL a where
   minlatL ::
-    Lens a String
+    Lens' a String
 

--- a/src/Data/Geo/OSM/Lens/MinlonL.hs
+++ b/src/Data/Geo/OSM/Lens/MinlonL.hs
@@ -1,9 +1,9 @@
 -- | Values with a @minlon@ string accessor.
 module Data.Geo.OSM.Lens.MinlonL where
 
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class MinlonL a where
   minlonL ::
-    Lens a String
+    Lens' a String
 

--- a/src/Data/Geo/OSM/Lens/NameL.hs
+++ b/src/Data/Geo/OSM/Lens/NameL.hs
@@ -1,9 +1,9 @@
 -- -- | Values with a @name@ string accessor.
 module Data.Geo.OSM.Lens.NameL where
 
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class NameL a where
   nameL ::
-    Lens a String
+    Lens' a String
 

--- a/src/Data/Geo/OSM/Lens/NdL.hs
+++ b/src/Data/Geo/OSM/Lens/NdL.hs
@@ -2,9 +2,9 @@
 module Data.Geo.OSM.Lens.NdL where
 
 import Data.Geo.OSM.Nd
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class NdL a where
   ndL ::
-    Lens a [Nd]
+    Lens' a [Nd]
 

--- a/src/Data/Geo/OSM/Lens/OriginL.hs
+++ b/src/Data/Geo/OSM/Lens/OriginL.hs
@@ -1,9 +1,9 @@
 -- | Values with a @origin@ optional string accessor.
 module Data.Geo.OSM.Lens.OriginL where
 
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class OriginL a where
   originL :: 
-    Lens a (Maybe String)
+    Lens' a (Maybe String)
 

--- a/src/Data/Geo/OSM/Lens/PendingL.hs
+++ b/src/Data/Geo/OSM/Lens/PendingL.hs
@@ -1,9 +1,9 @@
 -- | Values with a @pending@ boolean accessor.
 module Data.Geo.OSM.Lens.PendingL where
 
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class PendingL a where
   pendingL ::
-    Lens a Bool
+    Lens' a Bool
 

--- a/src/Data/Geo/OSM/Lens/PerPageL.hs
+++ b/src/Data/Geo/OSM/Lens/PerPageL.hs
@@ -1,9 +1,9 @@
 -- | Values with a @per_page@ string accessor.
 module Data.Geo.OSM.Lens.PerPageL where
 
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class PerPageL a where
   perPageL ::
-    Lens a String
+    Lens' a String
 

--- a/src/Data/Geo/OSM/Lens/PublicL.hs
+++ b/src/Data/Geo/OSM/Lens/PublicL.hs
@@ -1,9 +1,9 @@
 -- -- | Values with a @public@ boolean accessor.
 module Data.Geo.OSM.Lens.PublicL where
 
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class PublicL a where
   publicL ::
-    Lens a Bool
+    Lens' a Bool
 

--- a/src/Data/Geo/OSM/Lens/RefL.hs
+++ b/src/Data/Geo/OSM/Lens/RefL.hs
@@ -1,9 +1,9 @@
 -- | Values with a @ref@ string accessor.
 module Data.Geo.OSM.Lens.RefL where
 
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class RefL a where
   refL ::
-    Lens a String
+    Lens' a String
 

--- a/src/Data/Geo/OSM/Lens/RoleL.hs
+++ b/src/Data/Geo/OSM/Lens/RoleL.hs
@@ -1,9 +1,9 @@
 -- | Values with a @role@ string accessor.
 module Data.Geo.OSM.Lens.RoleL where
 
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class RoleL a where
   roleL ::
-    Lens a String
+    Lens' a String
 

--- a/src/Data/Geo/OSM/Lens/TagsL.hs
+++ b/src/Data/Geo/OSM/Lens/TagsL.hs
@@ -2,9 +2,9 @@
 module Data.Geo.OSM.Lens.TagsL where
 
 import Data.Geo.OSM.Tag
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class TagsL a where
   tagsL ::
-    Lens a [Tag]
+    Lens' a [Tag]
 

--- a/src/Data/Geo/OSM/Lens/TimestampL.hs
+++ b/src/Data/Geo/OSM/Lens/TimestampL.hs
@@ -3,9 +3,9 @@
 -- | Values with a @timestamp@ accessor.
 module Data.Geo.OSM.Lens.TimestampL where
 
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class TimestampL a b | a -> b where
   timestampL ::
-    Lens a b
+    Lens' a b
 

--- a/src/Data/Geo/OSM/Lens/TracepointsL.hs
+++ b/src/Data/Geo/OSM/Lens/TracepointsL.hs
@@ -2,9 +2,9 @@
 module Data.Geo.OSM.Lens.TracepointsL where
 
 import Data.Geo.OSM.Tracepoints
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class TracepointsL a where
   tracepointsL ::
-    Lens a Tracepoints
+    Lens' a Tracepoints
 

--- a/src/Data/Geo/OSM/Lens/TypeL.hs
+++ b/src/Data/Geo/OSM/Lens/TypeL.hs
@@ -2,9 +2,9 @@
 module Data.Geo.OSM.Lens.TypeL where
 
 import Data.Geo.OSM.MemberType
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class TypeL a where
   typeL ::
-    Lens a MemberType
+    Lens' a MemberType
 

--- a/src/Data/Geo/OSM/Lens/UidL.hs
+++ b/src/Data/Geo/OSM/Lens/UidL.hs
@@ -1,9 +1,9 @@
 -- | Values with a @uid@ optional string accessor.
 module Data.Geo.OSM.Lens.UidL where
 
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class UidL a where
   uidL ::
-    Lens a (Maybe String)
+    Lens' a (Maybe String)
 

--- a/src/Data/Geo/OSM/Lens/UserL.hs
+++ b/src/Data/Geo/OSM/Lens/UserL.hs
@@ -3,9 +3,9 @@
 -- | Values with a @user@ accessor.
 module Data.Geo.OSM.Lens.UserL where
 
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class UserL a b | a -> b where
   userL ::
-    Lens a b
+    Lens' a b
 

--- a/src/Data/Geo/OSM/Lens/VL.hs
+++ b/src/Data/Geo/OSM/Lens/VL.hs
@@ -1,9 +1,9 @@
 -- | Values with a @v@ string accessor.
 module Data.Geo.OSM.Lens.VL where
 
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class VL a where
   vL ::
-    Lens a String
+    Lens' a String
 

--- a/src/Data/Geo/OSM/Lens/VersionL.hs
+++ b/src/Data/Geo/OSM/Lens/VersionL.hs
@@ -3,9 +3,9 @@
 -- | Values with a @version@ accessor.
 module Data.Geo.OSM.Lens.VersionL where
 
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class VersionL a b | a -> b where
   versionL ::
-    Lens a b
+    Lens' a b
 

--- a/src/Data/Geo/OSM/Lens/VisibleL.hs
+++ b/src/Data/Geo/OSM/Lens/VisibleL.hs
@@ -1,9 +1,9 @@
 -- | Values with a @visible@ boolean accessor.
 module Data.Geo.OSM.Lens.VisibleL where
 
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class VisibleL a where
   visibleL ::
-    Lens a Bool
+    Lens' a Bool
 

--- a/src/Data/Geo/OSM/Lens/WaynodesL.hs
+++ b/src/Data/Geo/OSM/Lens/WaynodesL.hs
@@ -2,9 +2,9 @@
 module Data.Geo.OSM.Lens.WaynodesL where
 
 import Data.Geo.OSM.Waynodes
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class WaynodesL a where
   waynodesL ::
-    Lens a Waynodes
+    Lens' a Waynodes
 

--- a/src/Data/Geo/OSM/Lens/ZoomL.hs
+++ b/src/Data/Geo/OSM/Lens/ZoomL.hs
@@ -1,8 +1,8 @@
 -- | Values with a @zoom@ string accessor.
 module Data.Geo.OSM.Lens.ZoomL where
 
-import Data.Lens.Common
+import Control.Lens.Lens
 
 class ZoomL a where
   zoomL ::
-    Lens a String
+    Lens' a String

--- a/src/Data/Geo/OSM/Member.hs
+++ b/src/Data/Geo/OSM/Member.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TemplateHaskell #-}
 -- | The @member@ element of a OSM file.
 module Data.Geo.OSM.Member
 (
@@ -10,14 +11,16 @@ import Data.Geo.OSM.MemberType
 import Data.Geo.OSM.Lens.TypeL
 import Data.Geo.OSM.Lens.RefL
 import Data.Geo.OSM.Lens.RoleL
-import Control.Lens.Lens
-import Control.Comonad.Trans.Store
+import Control.Lens.TH
 
 -- | The @member@ element of a OSM file.
-data Member = 
-  Member MemberType String String
-  deriving Eq
+data Member = Member {
+  _memberType :: MemberType,
+  _memberRef :: String,
+  _memberRole :: String
+  } deriving Eq
 
+makeLenses ''Member
 instance XmlPickler Member where
   xpickle =
     xpElem "member" (xpWrap (\(mtype', mref', mrole') -> member mtype' mref' mrole', \(Member mtype' mref' mrole') -> (mtype', mref', mrole'))
@@ -28,16 +31,13 @@ instance Show Member where
     showPickled []
 
 instance TypeL Member where
-  typeL =
-    Lens $ \(Member typ ref role) -> store (\typ -> Member typ ref role) typ
+  typeL = memberType
 
 instance RefL Member where
-  refL =
-    Lens $ \(Member typ ref role) -> store (\ref -> Member typ ref role) ref
+  refL = memberRef
 
 instance RoleL Member where
-  roleL =
-    Lens $ \(Member typ ref role) -> store (\role -> Member typ ref role) role
+  roleL = memberRole
 
 -- | Constructs a member with a type, ref and role.
 member ::

--- a/src/Data/Geo/OSM/Member.hs
+++ b/src/Data/Geo/OSM/Member.hs
@@ -10,7 +10,7 @@ import Data.Geo.OSM.MemberType
 import Data.Geo.OSM.Lens.TypeL
 import Data.Geo.OSM.Lens.RefL
 import Data.Geo.OSM.Lens.RoleL
-import Data.Lens.Common
+import Control.Lens.Lens
 import Control.Comonad.Trans.Store
 
 -- | The @member@ element of a OSM file.

--- a/src/Data/Geo/OSM/NWRCommon.hs
+++ b/src/Data/Geo/OSM/NWRCommon.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE MultiParamTypeClasses, FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, CPP #-}
 
 -- | The common attributes between the @node@, @way@ and @relation@ elements.
 module Data.Geo.OSM.NWRCommon
@@ -7,8 +7,12 @@ module Data.Geo.OSM.NWRCommon
 , nwrCommon
 ) where
 
-import Text.XML.HXT.Arrow.Pickle
+#if __GLASGOW_HASKELL__ >= 800
+import Control.Applicative ()
+#else
 import Control.Applicative
+#endif
+import Text.XML.HXT.Arrow.Pickle
 import Data.Char
 import Data.Geo.OSM.Tag
 import Data.Geo.OSM.Lens.IdL

--- a/src/Data/Geo/OSM/NWRCommon.hs
+++ b/src/Data/Geo/OSM/NWRCommon.hs
@@ -23,7 +23,7 @@ import Data.Geo.OSM.Lens.UserL
 import Data.Geo.OSM.Lens.UidL
 import Data.Geo.OSM.Lens.TimestampL
 import Data.Geo.OSM.Lens.VersionL
-import Data.Lens.Common
+import Control.Lens.Lens
 import Control.Comonad.Trans.Store
 
 -- | The common attributes between the @node@, @way@ and @relation@ elements.

--- a/src/Data/Geo/OSM/Nd.hs
+++ b/src/Data/Geo/OSM/Nd.hs
@@ -9,7 +9,7 @@ module Data.Geo.OSM.Nd
 
 import Text.XML.HXT.Arrow.Pickle
 import Data.Geo.OSM.Lens.RefL
-import Data.Lens.Common
+import Control.Lens.Lens
 import Control.Comonad.Trans.Store
 import Control.Newtype
 

--- a/src/Data/Geo/OSM/Nd.hs
+++ b/src/Data/Geo/OSM/Nd.hs
@@ -10,7 +10,6 @@ module Data.Geo.OSM.Nd
 import Text.XML.HXT.Arrow.Pickle
 import Data.Geo.OSM.Lens.RefL
 import Control.Lens.Lens
-import Control.Comonad.Trans.Store
 import Control.Newtype
 
 -- | The @nd@ element of a OSM file.
@@ -23,15 +22,15 @@ instance XmlPickler Nd where
     xpElem "nd" (xpWrap (nd, \(Nd r) -> r) (xpAttr "ref" xpText))
 
 instance Show Nd where
-  show = 
+  show =
     showPickled []
 
 instance RefL Nd where
   refL =
-    Lens $ \(Nd ref) -> store (\ref -> Nd ref) ref
+    lens unpack (const pack)
 
 instance Newtype Nd String where
-  pack = 
+  pack =
     Nd
   unpack (Nd x) =
     x

--- a/src/Data/Geo/OSM/Node.hs
+++ b/src/Data/Geo/OSM/Node.hs
@@ -19,7 +19,7 @@ import Data.Geo.OSM.Lens.VisibleL
 import Data.Geo.OSM.Lens.UserL
 import Data.Geo.OSM.Lens.UidL
 import Data.Geo.OSM.Lens.TimestampL
-import Data.Lens.Common
+import Control.Lens.Lens
 import Control.Comonad.Trans.Store
 import Control.Category
 import Prelude hiding ((.))

--- a/src/Data/Geo/OSM/Node.hs
+++ b/src/Data/Geo/OSM/Node.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE MultiParamTypeClasses, FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, TemplateHaskell #-}
 
 -- | The @node@ element of a OSM file.
 module Data.Geo.OSM.Node
@@ -19,15 +19,19 @@ import Data.Geo.OSM.Lens.VisibleL
 import Data.Geo.OSM.Lens.UserL
 import Data.Geo.OSM.Lens.UidL
 import Data.Geo.OSM.Lens.TimestampL
-import Control.Lens.Lens
-import Control.Comonad.Trans.Store
-import Control.Category
-import Prelude hiding ((.))
+import Control.Lens.TH
 
 -- | The @node@ element of a OSM file.
-data Node =
-  Node String String NWRCommon
-  deriving Eq
+data Node = Node {
+  _nodeLat :: String,
+  _nodeLon :: String,
+  _nodeCommon :: NWRCommon
+  } deriving Eq
+
+makeLenses ''Node
+
+instance HasNWRCommon Node where
+  nWRCommon = nodeCommon
 
 instance XmlPickler Node where
   xpickle =
@@ -39,46 +43,31 @@ instance Show Node where
     showPickled []
 
 instance LatL Node where
-  latL =
-    Lens $ \(Node lat lon common) -> store (\lat -> Node lat lon common) lat
+  latL = nodeLat
 
 instance LonL Node where
-  lonL =
-    Lens $ \(Node lat lon common) -> store (\lon -> Node lat lon common) lon
-
--- not exported
-commonL ::
-  Lens Node NWRCommon
-commonL =
-  Lens (\(Node lat lon common) -> store (\common -> Node lat lon common) common)
+  lonL = nodeLon
 
 instance IdL Node where
-  idL =
-    idL . commonL
+  idL = commonId
 
 instance TagsL Node where
-  tagsL =
-    tagsL . commonL
+  tagsL = commonTags
 
 instance ChangesetL Node where
-  changesetL =
-    changesetL . commonL
+  changesetL = commonChangeset
 
 instance VisibleL Node where
-  visibleL = 
-    visibleL . commonL
+  visibleL = commonVisible
 
 instance UserL Node (Maybe String) where
-  userL =
-    userL . commonL
+  userL = nodeCommon . userL
 
 instance UidL Node where
-  uidL =
-    uidL . commonL
+  uidL = nodeCommon . uidL
 
 instance TimestampL Node (Maybe String) where
-  timestampL =
-    timestampL . commonL
+  timestampL = nodeCommon . timestampL
 
 -- | Constructs a node with a lat, lon, id, list of tags, changeset, visible, user&uid and timestamp.
 node ::

--- a/src/Data/Geo/OSM/OSM.hs
+++ b/src/Data/Geo/OSM/OSM.hs
@@ -27,7 +27,7 @@ import Data.Geo.OSM.Children
 import Data.Geo.OSM.Bound
 import Data.Geo.OSM.Bounds
 import Data.Geo.OSM.BoundOption
-import Data.Lens.Common
+import Control.Lens.Lens
 import Control.Comonad.Trans.Store
 import Data.Geo.OSM.Lens.VersionL
 import Data.Geo.OSM.Lens.GeneratorL

--- a/src/Data/Geo/OSM/Preferences.hs
+++ b/src/Data/Geo/OSM/Preferences.hs
@@ -11,7 +11,6 @@ import Text.XML.HXT.Arrow.Pickle
 import Data.Geo.OSM.Tag
 import Data.Geo.OSM.Lens.TagsL
 import Control.Lens.Lens
-import Control.Comonad.Trans.Store
 import Control.Newtype
 
 -- | The @preferences@ element of a OSM file.
@@ -36,11 +35,10 @@ instance Show Preferences where
 
 instance TagsL Preferences where
   tagsL =
-    Lens $ \(Preferences tags) -> store (\tags -> Preferences tags) tags
+    lens unpack (const pack)
 
 instance Newtype Preferences [Tag] where
-  pack = 
+  pack =
     Preferences
   unpack (Preferences x) =
     x
-

--- a/src/Data/Geo/OSM/Preferences.hs
+++ b/src/Data/Geo/OSM/Preferences.hs
@@ -10,7 +10,7 @@ module Data.Geo.OSM.Preferences
 import Text.XML.HXT.Arrow.Pickle
 import Data.Geo.OSM.Tag
 import Data.Geo.OSM.Lens.TagsL
-import Data.Lens.Common
+import Control.Lens.Lens
 import Control.Comonad.Trans.Store
 import Control.Newtype
 

--- a/src/Data/Geo/OSM/Relation.hs
+++ b/src/Data/Geo/OSM/Relation.hs
@@ -19,7 +19,7 @@ import Data.Geo.OSM.Lens.UserL
 import Data.Geo.OSM.Lens.UidL
 import Data.Geo.OSM.Lens.TimestampL
 import Data.Geo.OSM.Lens.MemberL
-import Data.Lens.Common
+import Control.Lens.Lens
 import Control.Comonad.Trans.Store
 import Control.Category
 import Prelude hiding ((.))

--- a/src/Data/Geo/OSM/Tag.hs
+++ b/src/Data/Geo/OSM/Tag.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TemplateHaskell #-}
 -- | The @tag@ element of a OSM file.
 module Data.Geo.OSM.Tag
 (
@@ -9,13 +10,16 @@ module Data.Geo.OSM.Tag
 import Text.XML.HXT.Arrow.Pickle
 import Data.Geo.OSM.Lens.KL
 import Data.Geo.OSM.Lens.VL
-import Control.Lens.Lens
-import Control.Comonad.Trans.Store
+import Control.Lens.TH
+
 
 -- | The @tag@ element of a OSM file.
-data Tag =
-  Tag String String
-  deriving Eq
+data Tag = Tag {
+  _tagKey :: String,
+  _tagValue :: String
+  } deriving Eq
+
+makeLenses ''Tag
 
 instance XmlPickler Tag where
   xpickle =
@@ -26,12 +30,11 @@ instance Show Tag where
     showPickled []
 
 instance KL Tag where
-  kL =
-    Lens $ \(Tag k v) -> store (\k -> Tag k v) k
+  kL = tagKey
 
 instance VL Tag where
-  vL =
-    Lens $ \(Tag k v) -> store (\v -> Tag k v) v
+  vL = tagValue
+
 
 -- | Constructs a tag with a key and value.
 tag ::

--- a/src/Data/Geo/OSM/Tag.hs
+++ b/src/Data/Geo/OSM/Tag.hs
@@ -9,7 +9,7 @@ module Data.Geo.OSM.Tag
 import Text.XML.HXT.Arrow.Pickle
 import Data.Geo.OSM.Lens.KL
 import Data.Geo.OSM.Lens.VL
-import Data.Lens.Common
+import Control.Lens.Lens
 import Control.Comonad.Trans.Store
 
 -- | The @tag@ element of a OSM file.

--- a/src/Data/Geo/OSM/Tracepoints.hs
+++ b/src/Data/Geo/OSM/Tracepoints.hs
@@ -11,7 +11,7 @@ module Data.Geo.OSM.Tracepoints
 import Text.XML.HXT.Arrow.Pickle
 import Data.Geo.OSM.Lens.PerPageL
 import Control.Lens.Lens
-import Control.Comonad.Trans.Store
+
 import Control.Newtype
 
 -- | The @tracepoints@ element of a OSM file.
@@ -36,11 +36,10 @@ instance Show Tracepoints where
 
 instance PerPageL Tracepoints where
   perPageL =
-    Lens $ \(Tracepoints perPage) -> store (\perPage -> Tracepoints perPage) perPage
+    lens unpack (const pack)
 
 instance Newtype Tracepoints String where
-  pack = 
+  pack =
     Tracepoints
   unpack (Tracepoints x) =
     x
-

--- a/src/Data/Geo/OSM/Tracepoints.hs
+++ b/src/Data/Geo/OSM/Tracepoints.hs
@@ -10,7 +10,7 @@ module Data.Geo.OSM.Tracepoints
 
 import Text.XML.HXT.Arrow.Pickle
 import Data.Geo.OSM.Lens.PerPageL
-import Data.Lens.Common
+import Control.Lens.Lens
 import Control.Comonad.Trans.Store
 import Control.Newtype
 

--- a/src/Data/Geo/OSM/User.hs
+++ b/src/Data/Geo/OSM/User.hs
@@ -10,7 +10,7 @@ import Data.Geo.OSM.Home
 import Data.Geo.OSM.Lens.HomeL
 import Data.Geo.OSM.Lens.DisplayNameL
 import Data.Geo.OSM.Lens.AccountCreatedL
-import Data.Lens.Common
+import Control.Lens.Lens
 import Control.Comonad.Trans.Store
 
 -- | The @user@ element of a OSM file.

--- a/src/Data/Geo/OSM/User.hs
+++ b/src/Data/Geo/OSM/User.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TemplateHaskell #-}
 -- | The @user@ element of a OSM file.
 module Data.Geo.OSM.User
 (
@@ -10,13 +11,18 @@ import Data.Geo.OSM.Home
 import Data.Geo.OSM.Lens.HomeL
 import Data.Geo.OSM.Lens.DisplayNameL
 import Data.Geo.OSM.Lens.AccountCreatedL
-import Control.Lens.Lens
-import Control.Comonad.Trans.Store
+
+
+import Control.Lens.TH
 
 -- | The @user@ element of a OSM file.
-data User =
-  User (Maybe Home) String String
-  deriving Eq
+data User = User {
+  _userHome :: Maybe Home,
+  _userDisplayName :: String,
+  _userAccountCreated :: String
+  } deriving Eq
+
+makeLenses ''User
 
 -- | Constructs a @user@ with an optional home, display_name and account_created.
 user ::
@@ -36,14 +42,10 @@ instance Show User where
     showPickled []
 
 instance HomeL User where
-  homeL =
-    Lens $ \(User home displayName accountCreated) -> store (\home -> User home displayName accountCreated) home
+  homeL = userHome
 
 instance DisplayNameL User where
-  displayNameL =
-    Lens $ \(User home displayName accountCreated) -> store (\displayName -> User home displayName accountCreated) displayName
+  displayNameL = userDisplayName
 
 instance AccountCreatedL User where
-  accountCreatedL =
-    Lens $ \(User home displayName accountCreated) -> store (\accountCreated -> User home displayName accountCreated) accountCreated
-
+  accountCreatedL = userAccountCreated

--- a/src/Data/Geo/OSM/Version.hs
+++ b/src/Data/Geo/OSM/Version.hs
@@ -9,7 +9,7 @@ module Data.Geo.OSM.Version
 import Text.XML.HXT.Arrow.Pickle
 import Data.Geo.OSM.Lens.MinimumL
 import Data.Geo.OSM.Lens.MaximumL
-import Data.Lens.Common
+import Control.Lens.Lens
 import Control.Comonad.Trans.Store
 
 -- | The @version@ element of a OSM file.

--- a/src/Data/Geo/OSM/Version.hs
+++ b/src/Data/Geo/OSM/Version.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 -- | The @version@ element of a OSM file.
 module Data.Geo.OSM.Version
 (
@@ -9,13 +11,15 @@ module Data.Geo.OSM.Version
 import Text.XML.HXT.Arrow.Pickle
 import Data.Geo.OSM.Lens.MinimumL
 import Data.Geo.OSM.Lens.MaximumL
-import Control.Lens.Lens
-import Control.Comonad.Trans.Store
+import Control.Lens.TH
 
 -- | The @version@ element of a OSM file.
-data Version =
-  Version String String
-  deriving Eq
+data Version = Version {
+  _versionMinimum :: String,
+  _versionMaximum :: String
+  } deriving Eq
+
+makeLenses ''Version
 
 -- | Constructs a @version@ with minimum and maximum.
 version ::
@@ -34,10 +38,7 @@ instance Show Version where
     showPickled []
 
 instance MinimumL Version where
-  minimumL =
-    Lens $ \(Version minimum maximum) -> store (\minimum -> Version minimum maximum) minimum
+  minimumL = versionMinimum
 
 instance MaximumL Version where
-  maximumL =
-    Lens $ \(Version minimum maximum) -> store (\maximum -> Version minimum maximum) maximum
-
+  maximumL = versionMaximum

--- a/src/Data/Geo/OSM/Way.hs
+++ b/src/Data/Geo/OSM/Way.hs
@@ -19,7 +19,7 @@ import Data.Geo.OSM.Lens.VisibleL
 import Data.Geo.OSM.Lens.UserL
 import Data.Geo.OSM.Lens.UidL
 import Data.Geo.OSM.Lens.TimestampL
-import Data.Lens.Common
+import Control.Lens.Lens
 import Control.Comonad.Trans.Store
 import Control.Category
 import Prelude hiding ((.))

--- a/src/Data/Geo/OSM/Waynodes.hs
+++ b/src/Data/Geo/OSM/Waynodes.hs
@@ -10,7 +10,7 @@ module Data.Geo.OSM.Waynodes
 
 import Text.XML.HXT.Arrow.Pickle
 import Data.Geo.OSM.Lens.MaximumL
-import Data.Lens.Common
+import Control.Lens.Lens
 import Control.Comonad.Trans.Store
 import Control.Newtype
 

--- a/src/Data/Geo/OSM/Waynodes.hs
+++ b/src/Data/Geo/OSM/Waynodes.hs
@@ -11,7 +11,6 @@ module Data.Geo.OSM.Waynodes
 import Text.XML.HXT.Arrow.Pickle
 import Data.Geo.OSM.Lens.MaximumL
 import Control.Lens.Lens
-import Control.Comonad.Trans.Store
 import Control.Newtype
 
 -- | The @waynodes@ element of a OSM file.
@@ -36,11 +35,10 @@ instance Show Waynodes where
 
 instance MaximumL Waynodes where
   maximumL =
-    Lens $ \(Waynodes maximum) -> store (\maximum -> Waynodes maximum) maximum
+    lens unpack (const pack)
 
 instance Newtype Waynodes String where
-  pack = 
+  pack =
     Waynodes
   unpack (Waynodes x) =
     x
-

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,7 +3,4 @@ extra-package-dbs: []
 packages:
 - '.'
 
-extra-deps:
-- data-lens-2.11.1
-
 resolver: lts-7.7

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,9 @@
+flags: {}
+extra-package-dbs: []
+packages:
+- '.'
+
+extra-deps:
+- data-lens-2.11.1
+
+resolver: lts-7.7


### PR DESCRIPTION
- fixes #7 and #6 
- removes dependencies to ```data-lens``` and ```comonad```
- refactored to use ```lens``` 
- using TemplateHaskell to create most of the lenses
- no changes to exported API it self, but maybe some ```data-lens``` code no longer works (unsure if `Lens' a b` from `lens` and ```Lens a b``` from ```data-lens``` are 100% isomorph/comptabile)
- added stack file (compiles fine with GHC 8.1 on `lts-7.7` )
- fixes unused import warning for `Control.Applicative` on GHC >= 8.0 (using CPP)
